### PR TITLE
chore: upgrade node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM alpine:3.9
 
 # ------------------------------------------------------------------------------------------------------------------
-# nodejs 10.16.0
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.10/main nodejs=10.16.0-r0 npm=10.16.0-r0
+# nodejs 12.22.6
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.12/main nodejs=12.22.6-r0 npm=12.22.6-r0
 
 # ------------------------------------------------------------------------------------------------------------------
-# python 3.6.8 (https://github.com/frol/docker-alpine-python3/blob/master/Dockerfile)
+# python 3.6.9 (https://github.com/frol/docker-alpine-python3/blob/master/Dockerfile)
 RUN echo "**** install Python ****" && \
     apk add --no-cache python3 && \
     if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi && \
@@ -31,8 +31,8 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     && rm dotnet.tar.gz
 
-# ruby 2.5.5
-RUN apk add ruby=2.5.5-r0
+# ruby 2.5.8
+RUN apk add ruby=2.5.8-r0
 
 # other stuff
-RUN apk add bash git curl
+RUN apk add --no-cache bash git curl

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ a docker image with all the goodies needed to package [jsii](https://github.com/
 
 Currently includes:
 
- - NodeJS 10.16
- - OpenJDK 8
- - Python 3.6
- - .NET is not supported
- 
+- NodeJS 12.22
+- OpenJDK 8
+- Python 3.6
+- .NET 2.2


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

I noticed that the current `jsii/superchain` image throws errors about using Node 10:

```
> jsii-pacmak

!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!                                                                                                           !!
!!  Node v10.22.1 has reached end-of-life and will no longer be supported in new releases after 2021-09-01.  !!
!!  Please upgrade to a supported node version as soon as possible.                                          !!
!!                                                                                                           !!
!!  As of the current release, supported versions of node are:                                               !!
!!  - ^12.7.0                                                                                                !!
!!  - ^14.5.0                                                                                                !!
!!  - ^16.3.0                                                                                                !!
!!                                                                                                           !!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```

Therefore, this PR updates the version of Node to 12.x. Additionally, I had to bump ruby and python because they'll be updated when you rebuild the image.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
